### PR TITLE
Feature/#1

### DIFF
--- a/server/toaster/src/main/java/com/app/toaster/controller/response/timer/GetTimerResponseDto.java
+++ b/server/toaster/src/main/java/com/app/toaster/controller/response/timer/GetTimerResponseDto.java
@@ -1,15 +1,15 @@
-package com.app.toaster.controller.response.timer;
-
-import java.util.ArrayList;
-
-import com.app.toaster.domain.Reminder;
-
-public record GetTimerResponseDto (String categoryName,
-                                       String remindTime,
-                                       ArrayList<Integer> remindDates) {
-    public static GetTimerResponseDto of(Reminder reminder){
-        if(reminder.getCategory() == null)
-            return new GetTimerResponseDto("전체", reminder.getRemindTime().toString(), reminder.getRemindDates());
-        return new GetTimerResponseDto(reminder.getCategory().getTitle(), reminder.getRemindTime().toString(), reminder.getRemindDates());
-    }
-}
+// package com.app.toaster.controller.response.timer;
+//
+// import java.util.ArrayList;
+//
+// import com.app.toaster.domain.Reminder;
+//
+// public record GetTimerResponseDto (String categoryName,
+//                                        String remindTime,
+//                                        ArrayList<Integer> remindDates) {
+//     public static GetTimerResponseDto of(Reminder reminder){
+//         if(reminder.getCategory() == null)
+//             return new GetTimerResponseDto("전체", reminder.getRemindTime().toString(), reminder.getRemindDates());
+//         return new GetTimerResponseDto(reminder.getCategory().getTitle(), reminder.getRemindTime().toString(), reminder.getRemindDates());
+//     }
+// }

--- a/server/toaster/src/main/java/com/app/toaster/domain/Reminder.java
+++ b/server/toaster/src/main/java/com/app/toaster/domain/Reminder.java
@@ -25,7 +25,7 @@ public class Reminder{
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	Long id;
 
-	@ManyToOne(fetch = FetchType.EAGER)
+	@ManyToOne(fetch = FetchType.LAZY)
 	private User user;
 
 	@OneToOne

--- a/server/toaster/src/main/java/com/app/toaster/domain/Reminder.java
+++ b/server/toaster/src/main/java/com/app/toaster/domain/Reminder.java
@@ -25,7 +25,7 @@ public class Reminder{
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	Long id;
 
-	@ManyToOne(fetch = FetchType.LAZY)
+	@ManyToOne(fetch = FetchType.EAGER)
 	private User user;
 
 	@OneToOne

--- a/server/toaster/src/main/java/com/app/toaster/external/client/fcm/FCMScheduler.java
+++ b/server/toaster/src/main/java/com/app/toaster/external/client/fcm/FCMScheduler.java
@@ -43,10 +43,10 @@ public class FCMScheduler {
         log.info("리마인드 알람");
 
             // 오늘 요일
-        int today = LocalDateTime.now().getDayOfWeek().getValue();
+        String today = String.valueOf(LocalDateTime.now().getDayOfWeek().getValue());
 
 
-            timerRepository.findAll().stream().filter(reminder -> reminder.getRemindDates().contains(today)).forEach(timer -> {
+            timerRepository.findByRemindDatesContainingToday(today).forEach(timer -> {
                 LocalTime now = LocalTime.now();
 
                 //한국 시간대로 변환

--- a/server/toaster/src/main/java/com/app/toaster/external/client/sqs/SqsConsumer.java
+++ b/server/toaster/src/main/java/com/app/toaster/external/client/sqs/SqsConsumer.java
@@ -1,85 +1,71 @@
-// package com.app.toaster.external.client.sqs;
-//
-// import com.app.toaster.controller.request.timer.CreateCronRequestDto;
-// import com.app.toaster.controller.request.timer.UpdateCronDateTimeDto;
-// import com.app.toaster.external.client.fcm.FCMPushRequestDto;
-// import com.app.toaster.external.client.fcm.FCMService;
-// import com.app.toaster.service.timer.TimerService;
-// import com.fasterxml.jackson.databind.ObjectMapper;
-// import io.awspring.cloud.sqs.annotation.SqsListener;
-// import lombok.RequiredArgsConstructor;
-// import lombok.extern.slf4j.Slf4j;
-// import org.springframework.beans.factory.annotation.Value;
-// import org.springframework.messaging.handler.annotation.Headers;
-// import org.springframework.messaging.handler.annotation.Payload;
-// import org.springframework.stereotype.Component;
-// import software.amazon.awssdk.services.sqs.SqsAsyncClient;
-// import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
-//
-// import java.util.Map;
-// /**
-//  * 큐 대기열에 있는 메시지 목록을 조회하여 받아오는(pull) 역할
-//  *
-//  */
-// @Slf4j
-// @Component
-//
-// @RequiredArgsConstructor
-// public class SqsConsumer {
-//
-//     @Value("${cloud.aws.sqs.notification.url}")
-//     private String QUEUE_URL;
-//
-//     private final ObjectMapper objectMapper;
-//
-//     private final TimerService timerService;
-//     private final SqsAsyncClient sqsAsyncClient;
-//     private static final String SQS_CONSUME_LOG_MESSAGE =
-//             "====> [SQS Queue Response]\n" + "info: %s\n" + "header: %s\n";
-//
-//
-// //     SQS로부터 메시지를 받는 Listener | 메시지를 받은 이후의 삭제 정책을 NEVER로 지정
-// //     -> 절대 삭제 요청을 보내지 않고, ack 메서드를 호출할 때 삭제 요청을 보냄
-// //     @SqsListener(value = "${cloud.aws.sqs.notification.sender}")
-// //     public void consume(@Payload String payload, @Headers Map<String, String> headers) {
-// //         System.out.println("======== 수신 받음 ==============");
-// //
-// // //        log.info(headers.toString());
-// //
-// //         try {
-// //                 CreateCronRequestDto request = objectMapper.readValue(payload, CreateCronRequestDto.class);
-// //                 timerService.createTimer(request);
-// // //                log.info(SQS_CONSUME_LOG_MESSAGE + payload);
-// //
-// //         } catch (Exception e) {
-// //             log.error(e.getMessage(), e);
-// //         }
-// //     }
-// //
-// //     @SqsListener(value = "${cloud.aws.sqs.notification.updater}")
-// //     public void updater(@Payload String payload, @Headers Map<String, String> headers) {
-// //         System.out.println("======== 수신 받음 ==============");
-// //
-// //         //        log.info(headers.toString());
-// //
-// //         try {
-// //             UpdateCronDateTimeDto request = objectMapper.readValue(payload, UpdateCronDateTimeDto.class);
-// //             timerService.updateTimerDatetime(request);
-// //             //                log.info(SQS_CONSUME_LOG_MESSAGE + payload);
-// //         } catch (Exception e) {
-// //             log.error(e.getMessage(), e);
-// //         }
-// //     }
-//
-//
-//     private void deleteMessage(String receiptHandle) {
-//         System.out.println("========== deleteMessage =========");
-//         DeleteMessageRequest deleteMessageRequest = DeleteMessageRequest.builder()
-//                 .queueUrl(QUEUE_URL)
-//                 .receiptHandle(receiptHandle)
-//                 .build();
-//         sqsAsyncClient.deleteMessage(deleteMessageRequest);
-//     }
-//
-//
-// }
+package com.app.toaster.external.client.sqs;
+
+import com.app.toaster.controller.request.timer.CreateCronRequestDto;
+import com.app.toaster.controller.request.timer.UpdateCronDateTimeDto;
+import com.app.toaster.external.client.fcm.FCMPushRequestDto;
+import com.app.toaster.external.client.fcm.FCMService;
+import com.app.toaster.service.timer.TimerService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.awspring.cloud.sqs.annotation.SqsListener;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.messaging.handler.annotation.Headers;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
+
+import java.util.Map;
+/**
+ * 큐 대기열에 있는 메시지 목록을 조회하여 받아오는(pull) 역할
+ *
+ */
+@Slf4j
+@Component
+
+@RequiredArgsConstructor
+public class SqsConsumer {
+
+	@Value("${cloud.aws.sqs.notification.url}")
+	private String QUEUE_URL;
+
+	private final ObjectMapper objectMapper;
+
+	private final FCMService fcmService;
+	private final SqsAsyncClient sqsAsyncClient;
+	private static final String SQS_CONSUME_LOG_MESSAGE =
+		"====> [SQS Queue Response]\n" + "info: %s\n" + "header: %s\n";
+
+
+	//     SQS로부터 메시지를 받는 Listener | 메시지를 받은 이후의 삭제 정책을 NEVER로 지정
+	//     -> 절대 삭제 요청을 보내지 않고, ack 메서드를 호출할 때 삭제 요청을 보냄
+	@SqsListener(value = "${cloud.aws.sqs.notification.name}")
+	public void consume(@Payload String payload, @Headers Map<String, String> headers) {
+		System.out.println("======== 수신 받음 ==============");
+
+		//        log.info(headers.toString());
+
+		try {
+			FCMPushRequestDto request = objectMapper.readValue(payload, FCMPushRequestDto.class);
+			fcmService.pushAlarm(request);
+
+			//                log.info(SQS_CONSUME_LOG_MESSAGE + payload);
+
+		} catch (Exception e) {
+			log.error(e.getMessage(), e);
+		}
+	}
+
+
+	private void deleteMessage(String receiptHandle) {
+		System.out.println("========== deleteMessage =========");
+		DeleteMessageRequest deleteMessageRequest = DeleteMessageRequest.builder()
+			.queueUrl(QUEUE_URL)
+			.receiptHandle(receiptHandle)
+			.build();
+		sqsAsyncClient.deleteMessage(deleteMessageRequest);
+	}
+
+
+}

--- a/server/toaster/src/main/java/com/app/toaster/external/client/sqs/SqsConsumer.java
+++ b/server/toaster/src/main/java/com/app/toaster/external/client/sqs/SqsConsumer.java
@@ -1,0 +1,85 @@
+package com.app.toaster.external.client.sqs;
+
+import com.app.toaster.controller.request.timer.CreateCronRequestDto;
+import com.app.toaster.controller.request.timer.UpdateCronDateTimeDto;
+import com.app.toaster.external.client.fcm.FCMPushRequestDto;
+import com.app.toaster.external.client.fcm.FCMService;
+import com.app.toaster.service.timer.TimerService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.awspring.cloud.sqs.annotation.SqsListener;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.messaging.handler.annotation.Headers;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
+
+import java.util.Map;
+/**
+ * 큐 대기열에 있는 메시지 목록을 조회하여 받아오는(pull) 역할
+ *
+ */
+@Slf4j
+@Component
+
+@RequiredArgsConstructor
+public class SqsConsumer {
+
+    @Value("${cloud.aws.sqs.notification.url}")
+    private String QUEUE_URL;
+
+    private final ObjectMapper objectMapper;
+
+    private final TimerService timerService;
+    private final SqsAsyncClient sqsAsyncClient;
+    private static final String SQS_CONSUME_LOG_MESSAGE =
+            "====> [SQS Queue Response]\n" + "info: %s\n" + "header: %s\n";
+
+
+//     SQS로부터 메시지를 받는 Listener | 메시지를 받은 이후의 삭제 정책을 NEVER로 지정
+//     -> 절대 삭제 요청을 보내지 않고, ack 메서드를 호출할 때 삭제 요청을 보냄
+    @SqsListener(value = "${cloud.aws.sqs.notification.sender}")
+    public void consume(@Payload String payload, @Headers Map<String, String> headers) {
+        System.out.println("======== 수신 받음 ==============");
+
+//        log.info(headers.toString());
+
+        try {
+                CreateCronRequestDto request = objectMapper.readValue(payload, CreateCronRequestDto.class);
+                timerService.createTimer(request);
+//                log.info(SQS_CONSUME_LOG_MESSAGE + payload);
+
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+        }
+    }
+
+    @SqsListener(value = "${cloud.aws.sqs.notification.updater}")
+    public void updater(@Payload String payload, @Headers Map<String, String> headers) {
+        System.out.println("======== 수신 받음 ==============");
+
+        //        log.info(headers.toString());
+
+        try {
+            UpdateCronDateTimeDto request = objectMapper.readValue(payload, UpdateCronDateTimeDto.class);
+            timerService.updateTimerDatetime(request);
+            //                log.info(SQS_CONSUME_LOG_MESSAGE + payload);
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+        }
+    }
+
+
+    private void deleteMessage(String receiptHandle) {
+        System.out.println("========== deleteMessage =========");
+        DeleteMessageRequest deleteMessageRequest = DeleteMessageRequest.builder()
+                .queueUrl(QUEUE_URL)
+                .receiptHandle(receiptHandle)
+                .build();
+        sqsAsyncClient.deleteMessage(deleteMessageRequest);
+    }
+
+
+}

--- a/server/toaster/src/main/java/com/app/toaster/external/client/sqs/SqsConsumer.java
+++ b/server/toaster/src/main/java/com/app/toaster/external/client/sqs/SqsConsumer.java
@@ -1,85 +1,85 @@
-package com.app.toaster.external.client.sqs;
-
-import com.app.toaster.controller.request.timer.CreateCronRequestDto;
-import com.app.toaster.controller.request.timer.UpdateCronDateTimeDto;
-import com.app.toaster.external.client.fcm.FCMPushRequestDto;
-import com.app.toaster.external.client.fcm.FCMService;
-import com.app.toaster.service.timer.TimerService;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.awspring.cloud.sqs.annotation.SqsListener;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.messaging.handler.annotation.Headers;
-import org.springframework.messaging.handler.annotation.Payload;
-import org.springframework.stereotype.Component;
-import software.amazon.awssdk.services.sqs.SqsAsyncClient;
-import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
-
-import java.util.Map;
-/**
- * 큐 대기열에 있는 메시지 목록을 조회하여 받아오는(pull) 역할
- *
- */
-@Slf4j
-@Component
-
-@RequiredArgsConstructor
-public class SqsConsumer {
-
-    @Value("${cloud.aws.sqs.notification.url}")
-    private String QUEUE_URL;
-
-    private final ObjectMapper objectMapper;
-
-    private final TimerService timerService;
-    private final SqsAsyncClient sqsAsyncClient;
-    private static final String SQS_CONSUME_LOG_MESSAGE =
-            "====> [SQS Queue Response]\n" + "info: %s\n" + "header: %s\n";
-
-
-//     SQS로부터 메시지를 받는 Listener | 메시지를 받은 이후의 삭제 정책을 NEVER로 지정
-//     -> 절대 삭제 요청을 보내지 않고, ack 메서드를 호출할 때 삭제 요청을 보냄
-    @SqsListener(value = "${cloud.aws.sqs.notification.sender}")
-    public void consume(@Payload String payload, @Headers Map<String, String> headers) {
-        System.out.println("======== 수신 받음 ==============");
-
-//        log.info(headers.toString());
-
-        try {
-                CreateCronRequestDto request = objectMapper.readValue(payload, CreateCronRequestDto.class);
-                timerService.createTimer(request);
-//                log.info(SQS_CONSUME_LOG_MESSAGE + payload);
-
-        } catch (Exception e) {
-            log.error(e.getMessage(), e);
-        }
-    }
-
-    @SqsListener(value = "${cloud.aws.sqs.notification.updater}")
-    public void updater(@Payload String payload, @Headers Map<String, String> headers) {
-        System.out.println("======== 수신 받음 ==============");
-
-        //        log.info(headers.toString());
-
-        try {
-            UpdateCronDateTimeDto request = objectMapper.readValue(payload, UpdateCronDateTimeDto.class);
-            timerService.updateTimerDatetime(request);
-            //                log.info(SQS_CONSUME_LOG_MESSAGE + payload);
-        } catch (Exception e) {
-            log.error(e.getMessage(), e);
-        }
-    }
-
-
-    private void deleteMessage(String receiptHandle) {
-        System.out.println("========== deleteMessage =========");
-        DeleteMessageRequest deleteMessageRequest = DeleteMessageRequest.builder()
-                .queueUrl(QUEUE_URL)
-                .receiptHandle(receiptHandle)
-                .build();
-        sqsAsyncClient.deleteMessage(deleteMessageRequest);
-    }
-
-
-}
+// package com.app.toaster.external.client.sqs;
+//
+// import com.app.toaster.controller.request.timer.CreateCronRequestDto;
+// import com.app.toaster.controller.request.timer.UpdateCronDateTimeDto;
+// import com.app.toaster.external.client.fcm.FCMPushRequestDto;
+// import com.app.toaster.external.client.fcm.FCMService;
+// import com.app.toaster.service.timer.TimerService;
+// import com.fasterxml.jackson.databind.ObjectMapper;
+// import io.awspring.cloud.sqs.annotation.SqsListener;
+// import lombok.RequiredArgsConstructor;
+// import lombok.extern.slf4j.Slf4j;
+// import org.springframework.beans.factory.annotation.Value;
+// import org.springframework.messaging.handler.annotation.Headers;
+// import org.springframework.messaging.handler.annotation.Payload;
+// import org.springframework.stereotype.Component;
+// import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+// import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
+//
+// import java.util.Map;
+// /**
+//  * 큐 대기열에 있는 메시지 목록을 조회하여 받아오는(pull) 역할
+//  *
+//  */
+// @Slf4j
+// @Component
+//
+// @RequiredArgsConstructor
+// public class SqsConsumer {
+//
+//     @Value("${cloud.aws.sqs.notification.url}")
+//     private String QUEUE_URL;
+//
+//     private final ObjectMapper objectMapper;
+//
+//     private final TimerService timerService;
+//     private final SqsAsyncClient sqsAsyncClient;
+//     private static final String SQS_CONSUME_LOG_MESSAGE =
+//             "====> [SQS Queue Response]\n" + "info: %s\n" + "header: %s\n";
+//
+//
+// //     SQS로부터 메시지를 받는 Listener | 메시지를 받은 이후의 삭제 정책을 NEVER로 지정
+// //     -> 절대 삭제 요청을 보내지 않고, ack 메서드를 호출할 때 삭제 요청을 보냄
+// //     @SqsListener(value = "${cloud.aws.sqs.notification.sender}")
+// //     public void consume(@Payload String payload, @Headers Map<String, String> headers) {
+// //         System.out.println("======== 수신 받음 ==============");
+// //
+// // //        log.info(headers.toString());
+// //
+// //         try {
+// //                 CreateCronRequestDto request = objectMapper.readValue(payload, CreateCronRequestDto.class);
+// //                 timerService.createTimer(request);
+// // //                log.info(SQS_CONSUME_LOG_MESSAGE + payload);
+// //
+// //         } catch (Exception e) {
+// //             log.error(e.getMessage(), e);
+// //         }
+// //     }
+// //
+// //     @SqsListener(value = "${cloud.aws.sqs.notification.updater}")
+// //     public void updater(@Payload String payload, @Headers Map<String, String> headers) {
+// //         System.out.println("======== 수신 받음 ==============");
+// //
+// //         //        log.info(headers.toString());
+// //
+// //         try {
+// //             UpdateCronDateTimeDto request = objectMapper.readValue(payload, UpdateCronDateTimeDto.class);
+// //             timerService.updateTimerDatetime(request);
+// //             //                log.info(SQS_CONSUME_LOG_MESSAGE + payload);
+// //         } catch (Exception e) {
+// //             log.error(e.getMessage(), e);
+// //         }
+// //     }
+//
+//
+//     private void deleteMessage(String receiptHandle) {
+//         System.out.println("========== deleteMessage =========");
+//         DeleteMessageRequest deleteMessageRequest = DeleteMessageRequest.builder()
+//                 .queueUrl(QUEUE_URL)
+//                 .receiptHandle(receiptHandle)
+//                 .build();
+//         sqsAsyncClient.deleteMessage(deleteMessageRequest);
+//     }
+//
+//
+// }

--- a/server/toaster/src/main/java/com/app/toaster/infrastructure/TimerRepository.java
+++ b/server/toaster/src/main/java/com/app/toaster/infrastructure/TimerRepository.java
@@ -26,7 +26,7 @@ public interface TimerRepository extends JpaRepository<Reminder, Long> {
     @Query("select r.category from Reminder r where r.id = :id")
     Category findCategoryByReminderId(@Param("id") Long reminderId);
 
-    @Query("SELECT r FROM Reminder r WHERE CAST(r.remindDates AS string) like :today")
+    @Query("SELECT r FROM Reminder r join fetch r.user where CAST(r.remindDates AS string) like :today")
     List<Reminder> findByRemindDatesContainingToday(@Param("today") String today);
 
 

--- a/server/toaster/src/main/java/com/app/toaster/infrastructure/TimerRepository.java
+++ b/server/toaster/src/main/java/com/app/toaster/infrastructure/TimerRepository.java
@@ -1,6 +1,7 @@
 package com.app.toaster.infrastructure;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -24,6 +25,9 @@ public interface TimerRepository extends JpaRepository<Reminder, Long> {
 
     @Query("select r.category from Reminder r where r.id = :id")
     Category findCategoryByReminderId(@Param("id") Long reminderId);
+
+    @Query("SELECT r FROM Reminder r WHERE CAST(r.remindDates AS string) like :today")
+    List<Reminder> findByRemindDatesContainingToday(@Param("today") String today);
 
 
 }


### PR DESCRIPTION
## 🚩 관련 이슈
- close #1 

## 📋 구현 기능 명세
- [x] 스케줄링 1분마다 조회해서 푸시알림 전송

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
먼저 고민을 했던 것은 spring batch도입을 할 것인가 였습니다. 쉬면서 스프링 배치에 대해서 공부해봤는데 물론 좋지만 정각에 다 가져오는 방식으로 해서 job을 등록하는 방식으로서 날짜 또한 파라미터로 가져와 등록하는 모습을 볼 수 있었는데 시간까지 고려할 때 거기 자체에서도 @Schedule을 써서 10분 간격으로 자신의 시간을 체크하고 일괄처리 시스템이라 정렬까지 잘 되어있어야 순차적으로 진행되는 모습을 봤습니다.
그래서 굳이 도입을 하기에는 애매하다고 생각했고 기존의 스케줄러를 사용해서 구현하는 것도 나쁘지않다고 생각되었습니다.

- 어떤 부분에 리뷰어가 집중해야 하는지
먼저, User를 불러올 때의 로직입니다. 우리는 현재 타이머에서 유저를 가지고 오는데 lazy로딩을 통해 불러왔었습니다. 그런데 우리가 timer에서 user를 가져올 때 실제 객체가 아닌 프록시를 가져와서 그런지 lazyinitialize와 관련된 예외가 발생했습니다. 그래서 fetch join을 통해 user와 관련된 애들을 함께 조회해서 해결했습니다.

다음으로는 우리 엔티티 관련된 내용입니다. 현재 timer에서는 converter를 이용해서 String타입으로 저장하고 있었는데 생각해보니 그렇기에 쿼리문에서 ex) member of 이런식으로 사용하면 리스트가 아니라서 작동하지 않았습니다. 그래서 date를 String으로 한번 변환시켜서 like로 조회하니 findAll을 하지않고도 쿼리를 좀 더 깔끔하게 바꿀 수 있었습니다.

- 개발하면서 어떤 점이 궁금했는지
일단 디비 분리와 관련해서도 궁금하긴하지만 현재 로직에서 1분마다 돌렸을 때의 메모리 사용량 등을 확인하고 싶습니다.
그리고 findbyCategory가 timer레포지토리에 들어있네요.. 뭔가 빼놓기에 private final로 하나 더 들고오는것보다는 저게 더 나을지 고민이네요.

## 📸 결과물 스크린샷
```java
Hibernate: 
    select
        r1_0.id,
        r1_0.category_category_id,
        r1_0.comment,
        r1_0.is_alarm,
        r1_0.remind_dates,
        r1_0.remind_time,
        r1_0.update_at,
        u1_0.user_id,
        u1_0.fcm_is_allowed,
        u1_0.fcm_token,
        u1_0.nickname,
        u1_0.profile,
        u1_0.refresh_token,
        u1_0.social_id,
        u1_0.social_type 
    from
        reminder r1_0 
    join
        user u1_0 
            on u1_0.user_id=r1_0.user_user_id 
    where
        cast(r1_0.remind_dates as char) like replace(?, '\\', '\\\\')
Hibernate: 
    select
        c1_0.category_id,
        c1_0.latest_read_time,
        c1_0.priority,
        r1_0.id,
        c2_0.category_id,
        c2_0.latest_read_time,
        c2_0.priority,
        c2_0.reminder_id,
        c2_0.title,
        c2_0.user_user_id,
        r1_0.comment,
        r1_0.is_alarm,
        r1_0.remind_dates,
        r1_0.remind_time,
        r1_0.update_at,
        r1_0.user_user_id,
        c1_0.title,
        c1_0.user_user_id 
    from
        category c1_0 
    left join
        reminder r1_0 
            on r1_0.id=c1_0.reminder_id 
    left join
        category c2_0 
            on c2_0.category_id=r1_0.category_category_id 
    where
        c1_0.category_id=?
=========================================
timer.getRemindTime().equals(koreaTime)
================= 전송시간 =================
Hibernate: 
    select
        count(t1_0.id) 
    from
        toast t1_0 
    where
        t1_0.user_id=? 
        and t1_0.is_read=0
Hibernate: 
    select
        c1_0.category_id,
        c1_0.latest_read_time,
        c1_0.priority,
        c1_0.reminder_id,
        c1_0.title,
        c1_0.user_user_id 
    from
        reminder r1_0 
    join
        category c1_0 
            on c1_0.category_id=r1_0.category_category_id 
    where
        r1_0.id=?
Sender: test2 클립 읽기 딱 좋은 시간이에요.
=========흠냐2님, 타이머가 완료되었어요!test2 클립 읽기 딱 좋은 시간이에요.=========
```

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- 