### PR TITLE
[#3] fix: like문에서 매일 검출 안되는 버그 수정

### DIFF
--- a/server/toaster/src/main/java/com/app/toaster/infrastructure/TimerRepository.java
+++ b/server/toaster/src/main/java/com/app/toaster/infrastructure/TimerRepository.java
@@ -26,7 +26,7 @@ public interface TimerRepository extends JpaRepository<Reminder, Long> {
     @Query("select r.category from Reminder r where r.id = :id")
     Category findCategoryByReminderId(@Param("id") Long reminderId);
 
-    @Query("SELECT r FROM Reminder r join fetch r.user where CAST(r.remindDates AS string) like :today")
+    @Query("SELECT r FROM Reminder r join fetch r.user where CAST(r.remindDates AS string) like %:today%")
     List<Reminder> findByRemindDatesContainingToday(@Param("today") String today);
 
 


### PR DESCRIPTION
## 🚩 관련 이슈
- close #3 

## 📋 구현 기능 명세
- [x] like관련해서 오류

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
매일 알림 울림이 실행안됨 이슈로 변경

- 어떤 부분에 리뷰어가 집중해야 하는지
like문에서 %를 앞뒤로 붙여줬어야했다.
